### PR TITLE
Loosen UiSchema type

### DIFF
--- a/packages/form/src/form/ui-schema.ts
+++ b/packages/form/src/form/ui-schema.ts
@@ -149,6 +149,10 @@ export interface UiOptions {
    * Default value to use when an input for a field is empty
    */
   emptyValue?: SchemaValue;
+  /**
+   * Allow for custom properties
+   */
+  [key: string]: boolean | number | string | object | any[] | null | undefined;
 }
 
 export type UiSchema = UiSchemaIndex & UiSchemaContent;


### PR DESCRIPTION
By loosening the `UiOptions` type, users can add custom fields to custom fields, widgets, and templates.

I'm attempting to create a custom object template, but I'm not able to add custom UI options in the following instance:

UiSchema
```ts
import type { UiSchemaRoot } from '@sjsf/form';

export const defaultConfigUISchema: UiSchemaRoot = {
	'ui:options': {
		customOption: true, // <----Error: Object literal may only specify known properties
	}
};

```
Custom Object Template
```svelte
<script lang="ts">
	import { type TemplateProps, getFormContext, getComponent, type Config } from '@sjsf/form';
	import { getTemplateProps } from './util';

	const ctx = getFormContext();

	const { config, children, addButton, errors }: TemplateProps<'object'> = $props();

	const Layout = $derived(getComponent(ctx, 'layout', config));
	const Title = $derived(getComponent(ctx, 'title', config));
	const Description = $derived(getComponent(ctx, 'description', config));
	const ErrorsList = $derived(getComponent(ctx, 'errorsList', config));

	const { showMeta, description, title } = $derived.by(() => {
		const { uiOptions: configUiOptions, schema: configSchema, title: configTitle } = config;
		return {
			title: configUiOptions?.title ?? configSchema.title ?? configTitle,
			showMeta: configUiOptions?.hideTitle !== true,
			description: configUiOptions?.description ?? configSchema.description,
			customOption: configUiOptions?.customOption ?? false // error here as well
		};
	});
</script>


<Layout type="object-field" attributes={config.uiOptions?.container} {config} {errors}>
	{#if showMeta && (title || description)}
		<Layout type="object-field-meta" {config} {errors}>
			{#if title}
				<Title
					type="object"
					forId={config.idSchema.$id}
					required={config.required}
					{config}
					{title}
					{errors}
				/>
			{/if}
			{#if description}
				<Description type="object" {description} {config} {errors} />
			{/if}
		</Layout>
	{/if}
	<Layout type="object-properties" attributes={config.uiOptions?.content} {config} {errors}>
		{@render children()}
	</Layout>
	{@render addButton?.()}
	{#if errors.length > 0}
		<ErrorsList forId={config.idSchema.$id} {errors} {config} />
	{/if}
</Layout>

```

This change keeps the current type safety while allowing arbitrary properties that aren't already specified. 

[RJSF Reference](https://github.com/rjsf-team/react-jsonschema-form/blob/5a3537e2f2fdcd87fac36a7ecbe5c88f56570321/packages/utils/src/types.ts#L934C3-L934C80)