### PR TITLE
[sveltekit] Add `uiSchema` to the `initForm` function call

### DIFF
--- a/.changeset/some-shrimps-accept.md
+++ b/.changeset/some-shrimps-accept.md
@@ -1,0 +1,5 @@
+---
+"@sjsf/sveltekit": minor
+---
+
+Allows uiSchema to be passed in initForm

--- a/apps/docs2/src/content/docs/integrations/_sveltekit-server.ts.api
+++ b/apps/docs2/src/content/docs/integrations/_sveltekit-server.ts.api
@@ -27,7 +27,7 @@ const schema: Schema = {
 };
 
 export const load = async () => {
-  const form = initForm({ schema, sendSchema: true });
+  const form = initForm({ schema, uiSchema, sendSchema: true });
   return { form };
 };
 

--- a/apps/docs2/src/content/docs/integrations/sveltekit.mdx
+++ b/apps/docs2/src/content/docs/integrations/sveltekit.mdx
@@ -74,7 +74,7 @@ import { initForm } from '@sjsf/sveltekit/server';
 
 export const load = async () => {
   const data = await getData();
-  const form = initForm({ schema, validator, initialValue: data });
+  const form = initForm({ schema, uiSchema, validator, initialValue: data });
   return { form };
 };
 ```

--- a/packages/sveltekit/src/lib/client/form.svelte.ts
+++ b/packages/sveltekit/src/lib/client/form.svelte.ts
@@ -4,6 +4,7 @@ import type { Validator } from '@sjsf/form/core';
 import {
   createForm,
   type Schema,
+  type UiSchemaRoot,
   type FormOptions,
   groupErrors,
   type PossibleError
@@ -19,9 +20,11 @@ import { createSvelteKitRequest, type SveltekitRequestOptions } from './request.
 type SchemaOption<SendSchema> = SendSchema extends true
   ? {
       schema?: Schema;
+      uiSchema?: UiSchemaRoot;
     }
   : {
       schema: Schema;
+      uiSchema?: UiSchemaRoot;
     };
 
 export type SvelteKitFormOptions<T, V extends Validator, SendSchema extends boolean> = Omit<
@@ -43,6 +46,7 @@ function initialFormData<Meta extends SvelteKitFormMeta<any, any, string, any>>(
         ? page.data[meta.name]
         : {
             schema: page.data[meta.name].schema,
+            uiSchema: page.data[meta.name].uiSchema, // I'm not sure if this does anything.
             initialValue: validationData.data,
             initialErrors: validationData.errors
           };

--- a/packages/sveltekit/src/lib/model.ts
+++ b/packages/sveltekit/src/lib/model.ts
@@ -1,4 +1,4 @@
-import type { IdentifiableFieldElement, Schema, SchemaValue, ValidationError } from '@sjsf/form';
+import type { IdentifiableFieldElement, Schema, UiSchemaRoot, SchemaValue, ValidationError } from '@sjsf/form';
 
 export const JSON_CHUNKS_KEY = '__sjsf_sveltekit_json_chunks';
 
@@ -6,6 +6,7 @@ export interface InitialFormData<T, E, SendSchema extends boolean> {
   initialValue: T | undefined;
   initialErrors: ValidationError<E>[];
   schema: SendSchema extends true ? Schema : undefined;
+  uiSchema: SendSchema extends true ? UiSchemaRoot : undefined;
 }
 
 export interface ValidatedFormData<E, SendData extends boolean> {

--- a/packages/sveltekit/src/lib/server/server.ts
+++ b/packages/sveltekit/src/lib/server/server.ts
@@ -29,13 +29,15 @@ export type InitFormOptions<T, E, SendSchema extends boolean> = {
   initialValue?: T;
   initialErrors?: ValidationError<E>[];
 } & (SendSchema extends true
-  ? { schema: Schema }
+  ? { schema: Schema, uiSchema?: UiSchemaRoot }
   : {
       schema?: never;
-    });
+      uiSchema?: never;
+    }) 
 
 export function initForm<T, E, SendSchema extends boolean = false>({
   schema,
+  uiSchema = undefined,
   initialValue,
   initialErrors = [],
   sendSchema
@@ -43,7 +45,8 @@ export function initForm<T, E, SendSchema extends boolean = false>({
   return {
     initialValue,
     initialErrors,
-    schema: (sendSchema ? schema : undefined) as SendSchema extends true ? Schema : undefined
+    schema: (sendSchema ? schema : undefined) as SendSchema extends true ? Schema : undefined,
+    uiSchema: (sendSchema ? uiSchema : undefined) as SendSchema extends true ? UiSchemaRoot : undefined
   };
 }
 

--- a/packages/sveltekit/src/routes/+page.server.ts
+++ b/packages/sveltekit/src/routes/+page.server.ts
@@ -15,7 +15,7 @@ export const load = async () => {
   const form = initForm({
     initialValue: { 'newKey::123': 'foo', 'also.333': 'bar' },
     sendSchema: true,
-    schema
+    schema,
   });
   return { form };
 };


### PR DESCRIPTION
Thank you for maintaining this repository. I've found it very helpful after discovering it in the Svelte Discord server. My team uses it to decrease the developer overhead of creating forms and respective validators each time.  

I found that I was unable to pass uiSchema in initForm. I ended up monkeypatching the package (going into `node_modules` and allowing uiSchema to be specified in `initform()`).

This is my first time attempting to contribute to a typescript repository, so please forgive my naivete. I was unable to run the tests due to a failure to resolve `@sjsf/basic-theme`. However, using my fork as a git dependency fulfilled the same purpose as my monkeypatch solution.