### PR TITLE
[themes] Remove deprecated prefixed date range picker widget names

### DIFF
--- a/.changeset/remove-theme-deprecated.md
+++ b/.changeset/remove-theme-deprecated.md
@@ -1,0 +1,11 @@
+---
+"@sjsf/shadcn4-theme": major
+"@sjsf/skeleton4-theme": major
+"@sjsf/svar-theme": major
+---
+
+Removed deprecated prefixed date range picker widget names:
+
+- `skeleton4DateRangePickerWidget` — use `dateRangePickerWidget` instead.
+- `shadcn4DateRangePickerWidget` — use `dateRangePickerWidget` instead.
+- `svarDateRangePickerWidget` — use `dateRangePickerWidget` instead.

--- a/apps/docs2/src/content/docs/misc/migration-from-v3.mdx
+++ b/apps/docs2/src/content/docs/misc/migration-from-v3.mdx
@@ -56,6 +56,31 @@ use `.current` instead. `SingleSelectOptions.hasInitialValue` has been removed
 - `idMapper()` — use `resolveEnumValueMapperBuilder()` + `builder.build()`.
 - `isSchemaExpandable()` — use `isObjectSchemaExpandable()`.
 - `UNDEFINED_ID` — use `EMPTY_VALUE` instead.
+- `FormErrorsMap` type — use `SvelteMap<FieldPath, string[]>` directly.
+- `setFormContext2` — use `setFormContext`.
+- `KeyedArray2` type — use `KeyedArray`.
+- `validateByRetrievedSchema` option — use `retrieveSchema` from `@sjsf/form/core`.
+- `DEFAULT_AUGMENT_SUFFIX` — use `idAugmentations` on `FragmentSchemaOptions`.
+- `augmentSuffix` on `FragmentSchemaOptions` — use `idAugmentations`.
+- `Query.result` — use `Query.current`.
+- `getSelectOptionValues()` — use `getSelectOptionValuesSafe()`.
+- `@sjsf/form/fields/any-of` — use `@sjsf/form/fields/combination/any-of`.
+- `@sjsf/form/fields/one-of` — use `@sjsf/form/fields/combination/one-of`.
+- `@sjsf/form/fields/combination` — use `@sjsf/form/fields/combination/combination`.
+- `Config.value` is now required.
+
+## Validator packages
+
+- `LegacyValidatorOptions` (`validateFunctions`, `augmentSuffix`, `ast`) removed — use
+  `validatorRetriever` directly (ajv8, schemasafe, ata, hyperjump).
+- `setupFormValidator` removed — use `adapt` (zod4, valibot).
+- `setupAsyncFormValidator` removed — use `adaptAsync` (zod4, valibot).
+
+## Theme packages
+
+- `skeleton4DateRangePickerWidget` removed — use `dateRangePickerWidget`.
+- `shadcn4DateRangePickerWidget` removed — use `dateRangePickerWidget`.
+- `svarDateRangePickerWidget` removed — use `dateRangePickerWidget`.
 
 ## Etc.
 

--- a/lab/svar-theme/src/lib/extra-widgets/date-range-picker-include.ts
+++ b/lab/svar-theme/src/lib/extra-widgets/date-range-picker-include.ts
@@ -4,12 +4,8 @@ import "./date-range-picker.svelte";
 
 declare module "../definitions.js" {
   interface ExtraWidgets {
-    // TODO: Remove in v4
-    /** @deprecated use `dateRangePickerWidget` instead */
-    svarDateRangePickerWidget: {};
     dateRangePickerWidget: {};
   }
 }
 
 definitions.dateRangePickerWidget = DateRangePicker;
-definitions.svarDateRangePickerWidget = DateRangePicker;

--- a/lab/svar-theme/src/lib/extra-widgets/date-range-picker.svelte
+++ b/lab/svar-theme/src/lib/extra-widgets/date-range-picker.svelte
@@ -7,14 +7,10 @@
 
   declare module "@sjsf/form" {
     interface ComponentProps {
-      // TODO: Remove in v4
-      /** @deprecated use `dateRangePickerWidget` instead */
-      svarDateRangePickerWidget: WidgetCommonProps<Partial<Range<string>>>;
+      dateRangePickerWidget: WidgetCommonProps<Partial<Range<string>>>;
     }
     interface ComponentBindings {
-      // TODO: Remove in v4
-      /** @deprecated use `dateRangePickerWidget` instead */
-      svarDateRangePickerWidget: "value";
+      dateRangePickerWidget: "value";
     }
     interface UiOptions {
       svarDateRangePicker?: SvelteComponentProps<typeof SvarDateRangePicker>;

--- a/legacy/skeleton4-theme/src/lib/extra-widgets/date-range-picker-include.ts
+++ b/legacy/skeleton4-theme/src/lib/extra-widgets/date-range-picker-include.ts
@@ -4,12 +4,8 @@ import "./date-range-picker.svelte";
 
 declare module "../definitions.js" {
   interface ExtraWidgets {
-    // TODO: Remove in v4
-    /** @deprecated use `dateRangePickerWidget` instead */
-    skeleton4DateRangePickerWidget: {};
     dateRangePickerWidget: {};
   }
 }
 
-definitions.skeleton4DateRangePickerWidget = DateRangePicker;
 definitions.dateRangePickerWidget = DateRangePicker;

--- a/legacy/skeleton4-theme/src/lib/extra-widgets/date-range-picker.svelte
+++ b/legacy/skeleton4-theme/src/lib/extra-widgets/date-range-picker.svelte
@@ -9,14 +9,10 @@
 
   declare module "@sjsf/form" {
     interface ComponentProps {
-      // TODO: Remove in v4
-      /** @deprecated use `dateRangePickerWidget` instead */
-      skeleton4DateRangePickerWidget: WidgetCommonProps<Partial<Range<string>>>;
+      dateRangePickerWidget: WidgetCommonProps<Partial<Range<string>>>;
     }
     interface ComponentBindings {
-      // TODO: Remove in v4
-      /** @deprecated use `dateRangePickerWidget` instead */
-      skeleton4DateRangePickerWidget: "value";
+      dateRangePickerWidget: "value";
     }
     interface UiOptions {
       skeleton4DateRangePicker?: DatePickerRootProps;

--- a/packages/shadcn4-theme/src/lib/theme/extra-widgets/date-range-picker-include.ts
+++ b/packages/shadcn4-theme/src/lib/theme/extra-widgets/date-range-picker-include.ts
@@ -4,12 +4,8 @@ import "./date-range-picker.svelte";
 
 declare module "../definitions.js" {
   interface ExtraWidgets {
-    // TODO: Remove in v4
-    /** @deprecated use `dateRangePickerWidget` instead */
-    shadcn4DateRangePickerWidget: {};
     dateRangePickerWidget: {};
   }
 }
 
 definitions.dateRangePickerWidget = DateRangePicker;
-definitions.shadcn4DateRangePickerWidget = DateRangePicker;

--- a/packages/shadcn4-theme/src/lib/theme/extra-widgets/date-range-picker.svelte
+++ b/packages/shadcn4-theme/src/lib/theme/extra-widgets/date-range-picker.svelte
@@ -13,14 +13,10 @@
 
   declare module "@sjsf/form" {
     interface ComponentProps {
-      // TODO: Remove in v4
-      /** @deprecated use `dateRangePickerWidget` instead */
-      shadcn4DateRangePickerWidget: WidgetCommonProps<Partial<Range<string>>>;
+      dateRangePickerWidget: WidgetCommonProps<Partial<Range<string>>>;
     }
     interface ComponentBindings {
-      // TODO: Remove in v4
-      /** @deprecated use `dateRangePickerWidget` instead */
-      shadcn4DateRangePickerWidget: "value";
+      dateRangePickerWidget: "value";
     }
     interface UiOptions {
       shadcn4DateRangePicker?: RangeCalendarRootProps;


### PR DESCRIPTION
- Remove skeleton4DateRangePickerWidget (use dateRangePickerWidget)
- Remove shadcn4DateRangePickerWidget (use dateRangePickerWidget)
- Remove svarDateRangePickerWidget (use dateRangePickerWidget)
- Update migration guide with all v4 deprecation removals