### PR TITLE
[meta] Remove deprecated playground/builder APIs and normalize state types

### DIFF
--- a/apps/builder/src/builder/context.svelte.ts
+++ b/apps/builder/src/builder/context.svelte.ts
@@ -8,7 +8,6 @@ import {
   themeCustomizableNodeTypes,
   themeRangeValueTypes,
   NodeType,
-  normalizeBuilderValidator,
   createSandboxFiles,
   type BuilderValidator2,
   type WidgetType,
@@ -17,7 +16,7 @@ import {
   builderValidatorTitle,
 } from "meta/builder";
 import type {
-  NormalizedFormPreset,
+  FormPreset,
   PlaygroundIconSet,
   PlaygroundResolver,
   PlaygroundTheme,
@@ -178,7 +177,11 @@ export class BuilderContext {
   theme = $state.raw<PlaygroundTheme>("shadcn4");
   resolver = $state.raw<PlaygroundResolver>("basic");
   icons = $state.raw<PlaygroundIconSet>("none");
-  validator = $state.raw<BuilderValidator2>(normalizeBuilderValidator("ajv8"));
+  validator = $state.raw<BuilderValidator2>({
+    name: "ajv8",
+    draft2020: false,
+    precompiled: false,
+  });
   readonly availableCustomizableNodeTypes = $derived(
     themeCustomizableNodeTypes(this.theme)
   );
@@ -481,10 +484,7 @@ export class BuilderContext {
   }
 
   importState(data: State) {
-    Object.assign(this, {
-      ...data,
-      validator: normalizeBuilderValidator(data.validator),
-    });
+    Object.assign(this, data);
     if (this.route.name === RouteName.Preview) {
       this.build();
     }
@@ -504,7 +504,7 @@ export class BuilderContext {
     });
   }
 
-  createPlaygroundSample(): Readonly<NormalizedFormPreset> {
+  createPlaygroundSample(): Readonly<FormPreset> {
     const validator = this.validator;
     return {
       schema: buildPlaygroundSchema({
@@ -512,7 +512,7 @@ export class BuilderContext {
         validator,
       }),
       uiSchema: JSON.stringify(this.uiSchema ?? {}),
-      initialValue: "null",
+      formData: "null",
       validator,
       theme: this.theme,
       resolver: this.resolver,

--- a/apps/playground2/src/form/form.svelte
+++ b/apps/playground2/src/form/form.svelte
@@ -64,11 +64,10 @@
     playgroundResolvers,
     playgroundThemes,
     type FormState,
-    normalizeFormState,
     parseFormData,
     parseUiSchema,
     type PresetEntry,
-    type NormalizedFormPreset,
+    type FormPreset,
     schemaTypeFromValidator,
     NESTED_DEFAULTS_PRECEDENCE_TITLES,
     NESTED_DEFAULTS_PRECEDENCE,
@@ -131,7 +130,7 @@
   import SamplePicker from "./sample-picker.svelte";
 
   const DEFAULT_PLAYGROUND_STATE: FormState = {
-    schema: {
+    schema: JSON.stringify({
       type: "object",
       title: "Basic form",
       properties: {
@@ -141,16 +140,16 @@
         },
       },
       required: ["hello"],
-    },
-    uiSchema: {},
-    initialValue: null,
+    }),
+    uiSchema: JSON.stringify({}),
+    formData: "null",
     css: "",
     disabled: false,
     html5Validation: false,
     focusOnFirstError: true,
     omitExtraData: false,
     fieldsValidationMode: 0,
-    validator: "ajv8",
+    validator: { name: "ajv8", draft2020: false, precompiled: false },
     theme: "basic",
     icons: "none",
     resolver: "compat",
@@ -161,13 +160,14 @@
     constAsDefault: "always",
     emptyObjectFields: "populateAllDefaults",
     mergeDefaultsIntoFormData: "useFormDataIfPresent",
+    nestedDefaultsPrecedence: "descendantWins",
   };
 
-  let originalInitialValue = $state.raw("");
+  let originalFormData = $state.raw("");
   const data = $state(
     (() => {
-      const data = normalizeFormState(router.load(DEFAULT_PLAYGROUND_STATE));
-      originalInitialValue = data.initialValue;
+      const data = router.load(DEFAULT_PLAYGROUND_STATE);
+      originalFormData = data.formData;
       return data;
     })()
   );
@@ -251,10 +251,10 @@
     })
   );
 
-  const initialValueQuery = createParseQuery({
+  const formDataQuery = createParseQuery({
     parse: parseFormData,
     get input() {
-      return data.initialValue;
+      return data.formData;
     },
     defaultValue: undefined,
   });
@@ -272,7 +272,7 @@
       return PLAYGROUND_RESOLVERS[data.resolver];
     },
     get initialValue() {
-      return initialValueQuery.value;
+      return formDataQuery.value;
     },
     get theme() {
       return theme;
@@ -350,7 +350,7 @@
   debouncedEffect(() => {
     const snap = $state.snapshot(data);
     valueSnapshotStr;
-    return () => router.store({ ...snap, initialValue: valueSnapshotStr });
+    return () => router.store({ ...snap, formData: valueSnapshotStr });
   });
 
   setShadcnContext();
@@ -471,7 +471,7 @@
     };
   });
 
-  type KeyName = "schema" | "uiSchema" | "initialValue" | "css";
+  type KeyName = "schema" | "uiSchema" | "formData" | "css";
 
   function toKeyName(k: string): KeyName | undefined {
     switch (k) {
@@ -480,7 +480,7 @@
       case "css":
         return k;
       case "preview":
-        return "initialValue";
+        return "formData";
     }
   }
 
@@ -490,7 +490,7 @@
 
   const format = createFormatTask();
 
-  const loadPresetTask = createTask<[PresetEntry], NormalizedFormPreset>({
+  const loadPresetTask = createTask<[PresetEntry], FormPreset>({
     combinator: abortPrevious,
     execute: debounce(async (s, { load, meta }) => {
       const preset = await load();
@@ -522,7 +522,7 @@
       };
     }),
     onSuccess(preset) {
-      originalInitialValue = preset.initialValue;
+      originalFormData = preset.formData;
       Object.assign(data, preset);
     },
     onFailure: createOnFailure("Example loading"),
@@ -726,7 +726,7 @@
     {#if tile.titles[tile.selectedTab] === FORM_DATA_TITLE}
       <Button
         onclick={() => {
-          data.initialValue = originalInitialValue;
+          data.formData = originalFormData;
         }}
         size="sm"
         variant="ghost"
@@ -776,11 +776,11 @@
     bind:value={
       () => valueSnapshotStr,
       (v) => {
-        data.initialValue = v;
+        data.formData = v;
       }
     }
     class="h-full"
-    data-state={initialValueQuery.state}
+    data-state={formDataQuery.state}
   />
 {/snippet}
 

--- a/apps/playground2/src/form/open-sandbox.ts
+++ b/apps/playground2/src/form/open-sandbox.ts
@@ -1,7 +1,7 @@
 import {
   createSandboxFiles,
   type CustomComponents,
-  type NormalizedFormState,
+  type FormState,
 } from "meta/playground";
 import { sandboxOpen, type SandboxPlatform } from "meta/sandbox";
 
@@ -9,7 +9,7 @@ import markdownDescriptionSource from "./custom-form-components/markdown-descrip
 import transparentLayoutSource from "./custom-form-components/transparent-layout.svelte?raw";
 
 export interface SandboxOptions {
-  formState: NormalizedFormState;
+  formState: FormState;
   platform: SandboxPlatform;
 }
 

--- a/apps/playground2/src/merger.svelte
+++ b/apps/playground2/src/merger.svelte
@@ -8,7 +8,6 @@
     createShallowAllOfMerge,
   } from "@sjsf/form/lib/json-schema";
   import {
-    normalizeMergerState,
     parseFormData,
     parseJsonSchema,
     type MergerState,
@@ -39,7 +38,7 @@
   import { createFormatTask, createParseQuery } from "./shared.svelte";
 
   const DEFAULT_PAGE_STATE: MergerState = {
-    schema: {
+    schema: JSON.stringify({
       allOf: [
         {
           type: "object",
@@ -49,15 +48,15 @@
         },
         { required: ["foo"] },
       ],
-    },
-    output: {},
+    }),
+    output: JSON.stringify({}),
     deep: false,
     intersectJson: false,
     deduplicateJsonSchemas: false,
   };
 
   const loadedState = router.load<MergerState>(DEFAULT_PAGE_STATE);
-  const data = $state(normalizeMergerState(loadedState));
+  const data = $state(loadedState);
 
   debouncedEffect(() => {
     const snap = $state.snapshot(data);

--- a/apps/playground2/src/omit.svelte
+++ b/apps/playground2/src/omit.svelte
@@ -213,7 +213,7 @@
 
 <Header
   transitions={{
-    "": () => ({ schema: data.schema, initialValue: data.input }),
+    "": () => ({ schema: data.schema, formData: data.input }),
     v: () => ({ schema: data.schema, input: data.input }),
     m: () => ({ schema: data.schema }),
     o: () => data,

--- a/apps/playground2/src/validator.svelte
+++ b/apps/playground2/src/validator.svelte
@@ -14,11 +14,7 @@
     debounce,
   } from "@sjsf/form/lib/task.svelte";
   import { createMerger as createSchemaMerger } from "@sjsf/form/mergers/modern";
-  import {
-    normalizeValidatorState,
-    parseFormData,
-    type ValidatorState,
-  } from "meta/playground";
+  import { parseFormData, type ValidatorState } from "meta/playground";
   import { Panel, setTilerContext, type Tiles } from "svelte-tiler";
   import { fromRecord } from "svelte-tiler/shared/registry";
   import * as Leaf from "svelte-tiler/tiles/leaf.svelte";
@@ -49,7 +45,7 @@
   } from "./shared.svelte";
 
   const DEFAULT_PAGE_STATE: ValidatorState = {
-    schema: {
+    schema: JSON.stringify({
       type: "object",
       title: "Basic form",
       properties: {
@@ -59,13 +55,13 @@
         },
       },
       required: ["hello"],
-    },
-    input: null,
-    output: undefined,
-    validator: "ajv8",
+    }),
+    input: "null",
+    output: "[]",
+    validator: { name: "ajv8", draft2020: false, precompiled: false },
   };
 
-  const data = $state(normalizeValidatorState(router.load(DEFAULT_PAGE_STATE)));
+  const data = $state(router.load(DEFAULT_PAGE_STATE));
 
   debouncedEffect(() => {
     const snap = $state.snapshot(data);
@@ -236,7 +232,7 @@
   transitions={{
     "": () => ({
       schema: data.schema,
-      initialValue: data.input,
+      formData: data.input,
       validator: data.validator,
     }),
     v: () => data,

--- a/packages/meta/src/builder/model.ts
+++ b/packages/meta/src/builder/model.ts
@@ -7,21 +7,6 @@ import {
 import { playgroundValidatorTitle } from "../playground/model.ts";
 import type { Generated } from "../types.ts";
 
-// TODO: Remove in v4
-/** @deprecated */
-export function* builderValidators() {
-  for (const v of codegenValidators()) {
-    if (!codegenIsExternalValidator(v) || v.draft2020 || v.precompiled) {
-      continue;
-    }
-    yield v.name;
-  }
-}
-
-// TODO: Remove in v4
-/** @deprecated */
-export type BuilderValidator1 = Generated<typeof builderValidators>;
-
 export function* builderValidators2() {
   for (const v of codegenValidators()) {
     if (!codegenIsExternalValidator(v) || v.draft2020) {
@@ -33,19 +18,7 @@ export function* builderValidators2() {
 
 export type BuilderValidator2 = Generated<typeof builderValidators2>;
 
-export type BuilderValidator = BuilderValidator1 | BuilderValidator2;
-
-export function normalizeBuilderValidator(
-  validator: BuilderValidator
-): BuilderValidator2 {
-  return typeof validator === "string"
-    ? ({
-        name: validator,
-        draft2020: false,
-        precompiled: false,
-      } as BuilderValidator2)
-    : ({ ...validator, draft2020: false } as BuilderValidator2);
-}
+export type BuilderValidator = BuilderValidator2;
 
 export function builderValidatorTitle(v: BuilderValidator2) {
   return playgroundValidatorTitle(v);

--- a/packages/meta/src/builder/sandbox.test.ts
+++ b/packages/meta/src/builder/sandbox.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from "vitest";
 
 import { codegenThemeOrSubTheme } from "../codegen/index.ts";
 import { jsonSchema } from "../playground/form-preset.ts";
-import { builderValidators2, normalizeBuilderValidator } from "./model.ts";
+import { builderValidators2 } from "./model.ts";
 import { createSandboxFiles, type BuilderSandboxOptions } from "./sandbox.ts";
 
 const BASE_OPTIONS: BuilderSandboxOptions = {
   name: "Sandbox",
   theme: "basic",
-  validator: normalizeBuilderValidator("ajv8"),
+  validator: { name: "ajv8", draft2020: false, precompiled: false },
   schema: jsonSchema({
     type: "object",
     title: "Test",

--- a/packages/meta/src/playground/form-preset-loaders.ts
+++ b/packages/meta/src/playground/form-preset-loaders.ts
@@ -1,5 +1,5 @@
 import type { CatalogEntry } from "../catalog.ts";
-import type { NormalizedFormPreset, PresetMeta } from "./form-preset.ts";
+import type { FormPreset, PresetMeta } from "./form-preset.ts";
 
 const PRESET_METADATA = import.meta.glob("./form-presets/*.js", {
   import: "meta",
@@ -10,13 +10,13 @@ const PRESET_LOADERS = import.meta.glob("./form-presets/*.js", {
   eager: false,
 });
 
-export type PresetEntry = CatalogEntry<PresetMeta, NormalizedFormPreset>;
+export type PresetEntry = CatalogEntry<PresetMeta, FormPreset>;
 
 export const SORTED_PRESETS: PresetEntry[] = Object.keys(PRESET_LOADERS)
   .map((path) => ({
     meta: PRESET_METADATA[path]! as PresetMeta,
     path,
-    load: PRESET_LOADERS[path]! as () => Promise<NormalizedFormPreset>,
+    load: PRESET_LOADERS[path]! as () => Promise<FormPreset>,
   }))
   .sort((a, b) => a.meta.title.localeCompare(b.meta.title));
 

--- a/packages/meta/src/playground/form-preset.ts
+++ b/packages/meta/src/playground/form-preset.ts
@@ -1,8 +1,10 @@
+import type { FormValue, Schema, UiSchemaRoot } from "@sjsf/form";
+
 import type { CatalogMeta } from "../catalog.ts";
-import type { FormState, NormalizedFormState } from "./form-state.ts";
+import type { FormState } from "./form-state.ts";
 import type { SchemaType } from "./typed-schema.ts";
 
-type RequiredFormPresetProperties = "schema" | "uiSchema" | "initialValue";
+type RequiredFormPresetProperties = "schema" | "uiSchema" | "formData";
 
 type Preset<T extends Record<string, any>> = Pick<
   T,
@@ -11,8 +13,6 @@ type Preset<T extends Record<string, any>> = Pick<
   Partial<Omit<T, RequiredFormPresetProperties>>;
 
 export type FormPreset = Preset<FormState>;
-
-export type NormalizedFormPreset = Preset<NormalizedFormState>;
 
 // NOTE: Order is important
 export enum FormPresetCategory {
@@ -44,21 +44,19 @@ export function defineMetadata(meta: PresetMeta): PresetMeta {
   return meta;
 }
 
-export function definePreset(
-  preset: NormalizedFormPreset
-): NormalizedFormPreset {
+export function definePreset(preset: FormPreset): FormPreset {
   return preset;
 }
 
-export function jsonSchema(schema: FormState["schema"]): string {
+export function jsonSchema(schema: Schema): string {
   return JSON.stringify(schema, null, 2);
 }
 
-export function jsonUiSchema(uiSchema: FormState["uiSchema"]): string {
+export function jsonUiSchema(uiSchema: UiSchemaRoot): string {
   return JSON.stringify(uiSchema, null, 2);
 }
 
-export function jsonValue(value: FormState["initialValue"]): string {
+export function jsonValue(value: FormValue): string {
   return JSON.stringify(value, null, 2);
 }
 

--- a/packages/meta/src/playground/form-presets/additional-properties.ts
+++ b/packages/meta/src/playground/form-presets/additional-properties.ts
@@ -53,7 +53,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     firstName: "Chuck",
     lastName: "Norris",
     assKickCount: "infinity",

--- a/packages/meta/src/playground/form-presets/all-of.ts
+++ b/packages/meta/src/playground/form-presets/all-of.ts
@@ -41,5 +41,5 @@ export default definePreset({
     ],
   }),
   uiSchema: jsonUiSchema({}),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/alternatives.ts
+++ b/packages/meta/src/playground/form-presets/alternatives.ts
@@ -107,7 +107,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     currentColor: "#00ff00",
     colorMask: ["#0000ff"],
     colorPalette: ["#ff0000"],

--- a/packages/meta/src/playground/form-presets/any-of.ts
+++ b/packages/meta/src/playground/form-presets/any-of.ts
@@ -75,5 +75,5 @@ export default definePreset({
     ],
   }),
   uiSchema: jsonUiSchema({}),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/arrays.ts
+++ b/packages/meta/src/playground/form-presets/arrays.ts
@@ -216,7 +216,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     listOfStrings: ["foo", "bar"],
     multipleChoicesList: ["foo", "bar"],
     fixedItemsList: ["Some text", true, 123],

--- a/packages/meta/src/playground/form-presets/date.ts
+++ b/packages/meta/src/playground/form-presets/date.ts
@@ -70,5 +70,5 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/defaults.ts
+++ b/packages/meta/src/playground/form-presets/defaults.ts
@@ -70,7 +70,7 @@ export default definePreset({
     },
   }),
   uiSchema: jsonUiSchema({}),
-  initialValue: jsonValue({
+  formData: jsonValue({
     valuesInFormData: {
       scalar: "value",
       array: [

--- a/packages/meta/src/playground/form-presets/draft-2020-12.ts
+++ b/packages/meta/src/playground/form-presets/draft-2020-12.ts
@@ -1,3 +1,5 @@
+import type { Schema } from "@sjsf/form";
+
 import {
   defineMetadata,
   definePreset,
@@ -7,7 +9,6 @@ import {
   jsonUiSchema,
   jsonValue,
 } from "../form-preset.ts";
-import type { FormState } from "../form-state.ts";
 
 export const meta = defineMetadata({
   category: FormPresetCategory.SchemaBasics,
@@ -57,7 +58,7 @@ export default definePreset({
         },
       },
     },
-  } as FormState["schema"]),
-  initialValue: jsonValue({}),
+  } as Schema),
+  formData: jsonValue({}),
   uiSchema: jsonUiSchema({}),
 });

--- a/packages/meta/src/playground/form-presets/enum-objects.ts
+++ b/packages/meta/src/playground/form-presets/enum-objects.ts
@@ -88,7 +88,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     location: {
       name: "Amsterdam",
       lat: 52,

--- a/packages/meta/src/playground/form-presets/errors.ts
+++ b/packages/meta/src/playground/form-presets/errors.ts
@@ -54,7 +54,7 @@ export default definePreset({
     },
   }),
   uiSchema: jsonUiSchema({}),
-  initialValue: jsonValue({
+  formData: jsonValue({
     firstName: "Chuck",
     active: "wrong",
     skills: ["karate", "budo", "aikido"],

--- a/packages/meta/src/playground/form-presets/examples.ts
+++ b/packages/meta/src/playground/form-presets/examples.ts
@@ -31,5 +31,5 @@ export default definePreset({
     },
   }),
   uiSchema: jsonUiSchema({}),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/files.ts
+++ b/packages/meta/src/playground/form-presets/files.ts
@@ -97,5 +97,5 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/grid.ts
+++ b/packages/meta/src/playground/form-presets/grid.ts
@@ -69,5 +69,5 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/if-then-else.ts
+++ b/packages/meta/src/playground/form-presets/if-then-else.ts
@@ -64,5 +64,5 @@ export default definePreset({
     ],
   }),
   uiSchema: jsonUiSchema({}),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/large.ts
+++ b/packages/meta/src/playground/form-presets/large.ts
@@ -65,5 +65,5 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/layout-grid.ts
+++ b/packages/meta/src/playground/form-presets/layout-grid.ts
@@ -459,5 +459,5 @@ export default definePreset({
       ],
     },
   }),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/nested.ts
+++ b/packages/meta/src/playground/form-presets/nested.ts
@@ -65,7 +65,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     title: "My current tasks",
     tasks: [
       {

--- a/packages/meta/src/playground/form-presets/null.ts
+++ b/packages/meta/src/playground/form-presets/null.ts
@@ -52,5 +52,5 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/nullable.ts
+++ b/packages/meta/src/playground/form-presets/nullable.ts
@@ -118,7 +118,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     lastName: "Norris",
     age: 75,
     bio: null,

--- a/packages/meta/src/playground/form-presets/numbers.ts
+++ b/packages/meta/src/playground/form-presets/numbers.ts
@@ -73,7 +73,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     number: 3.14,
     integer: 42,
     numberEnum: 2,

--- a/packages/meta/src/playground/form-presets/one-of-defaults.ts
+++ b/packages/meta/src/playground/form-presets/one-of-defaults.ts
@@ -226,7 +226,7 @@ export default definePreset({
   resolver: "compat",
   schema: jsonSchema(_schema),
   uiSchema: jsonUiSchema(_uiSchema),
-  initialValue: jsonValue({
+  formData: jsonValue({
     preset: TransformPreset.Default,
     transform: false,
     format: OutputFormat.HTML,

--- a/packages/meta/src/playground/form-presets/one-of.ts
+++ b/packages/meta/src/playground/form-presets/one-of.ts
@@ -39,5 +39,5 @@ export default definePreset({
     ],
   }),
   uiSchema: jsonUiSchema({}),
-  initialValue: jsonValue({}),
+  formData: jsonValue({}),
 });

--- a/packages/meta/src/playground/form-presets/ordering.ts
+++ b/packages/meta/src/playground/form-presets/ordering.ts
@@ -71,7 +71,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     firstName: "Chuck",
     lastName: "Norris",
     age: 75,

--- a/packages/meta/src/playground/form-presets/pattern-properties.ts
+++ b/packages/meta/src/playground/form-presets/pattern-properties.ts
@@ -62,7 +62,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     firstName: "Chuck",
     lastName: "Norris",
     fooPropertyExample: "foo",

--- a/packages/meta/src/playground/form-presets/property-dependencies.ts
+++ b/packages/meta/src/playground/form-presets/property-dependencies.ts
@@ -92,7 +92,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     unidirectional: {
       name: "Tim",
     },

--- a/packages/meta/src/playground/form-presets/property-names.ts
+++ b/packages/meta/src/playground/form-presets/property-names.ts
@@ -37,7 +37,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     foo: 123,
   }),
 });

--- a/packages/meta/src/playground/form-presets/references.ts
+++ b/packages/meta/src/playground/form-presets/references.ts
@@ -80,7 +80,7 @@ export default definePreset({
       $ref: "node",
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     billing_address: {
       street_address: "21, Jump Street",
       city: "Babel",

--- a/packages/meta/src/playground/form-presets/schema-dependencies.ts
+++ b/packages/meta/src/playground/form-presets/schema-dependencies.ts
@@ -164,7 +164,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     simple: {
       name: "Randy",
     },

--- a/packages/meta/src/playground/form-presets/simple.ts
+++ b/packages/meta/src/playground/form-presets/simple.ts
@@ -139,7 +139,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     lastName: "Norris",
     age: 75,
     bio: "Roundhouse kicking asses since 1940",

--- a/packages/meta/src/playground/form-presets/single.ts
+++ b/packages/meta/src/playground/form-presets/single.ts
@@ -21,6 +21,6 @@ export default definePreset({
     title: "A single-field form",
     type: "string",
   }),
-  initialValue: jsonValue("initial value"),
+  formData: jsonValue("initial value"),
   uiSchema: jsonUiSchema({}),
 });

--- a/packages/meta/src/playground/form-presets/ui-options.ts
+++ b/packages/meta/src/playground/form-presets/ui-options.ts
@@ -96,7 +96,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     lastName: "Norris",
     age: 75,
     bio: "Roundhouse kicking asses since 1940",

--- a/packages/meta/src/playground/form-presets/widgets.ts
+++ b/packages/meta/src/playground/form-presets/widgets.ts
@@ -240,7 +240,7 @@ export default definePreset({
       },
     },
   }),
-  initialValue: jsonValue({
+  formData: jsonValue({
     stringFormats: {
       email: "chuck@norris.net",
       uri: "http://chucknorris.com/",

--- a/packages/meta/src/playground/form-state.ts
+++ b/packages/meta/src/playground/form-state.ts
@@ -1,9 +1,4 @@
-import type {
-  FieldsValidationMode,
-  FormValue,
-  Schema,
-  UiSchemaRoot,
-} from "@sjsf/form";
+import type { FieldsValidationMode } from "@sjsf/form";
 import type {
   Experimental_ArrayMinItems,
   Experimental_DefaultFormStateBehavior,
@@ -14,20 +9,12 @@ import {
   type PlaygroundTheme,
   type PlaygroundIconSet,
   type PlaygroundResolver,
-  normalizeJsonValue,
-  type Normalize,
-  normalizeValidator,
 } from "./model.ts";
 
-// NOTE: We use legacy types in combination with `| string`
-// to maintain compatibility with old URLs.
-// TODO: This should be removed in v4.
 export interface FormState {
-  schema: Schema | string;
-  uiSchema: UiSchemaRoot | string;
-  // TODO: Replace with `formData: string` in v4
-  initialValue: FormValue | string;
-  //
+  schema: string;
+  uiSchema: string;
+  formData: string;
   disabled: boolean;
   html5Validation: boolean;
   focusOnFirstError: boolean;
@@ -37,7 +24,7 @@ export interface FormState {
   theme: PlaygroundTheme;
   icons: PlaygroundIconSet;
   resolver: PlaygroundResolver;
-  css?: string;
+  css: string;
   // Merger config
   arrayMinItemsPopulate: ArrayMinItemsPopulate;
   arrayMinItemsMergeExtraDefaults: boolean;
@@ -45,7 +32,7 @@ export interface FormState {
   constAsDefault: ConstAsDefaultStateBehavior;
   emptyObjectFields: EmptyObjectFieldsStateBehavior;
   mergeDefaultsIntoFormData: MergeDefaultsIntoFormDataStateBehavior;
-  nestedDefaultsPrecedence?: NestedDefaultsPrecedence;
+  nestedDefaultsPrecedence: NestedDefaultsPrecedence;
 }
 
 type ArrayMinItemsPopulate = Exclude<
@@ -155,19 +142,3 @@ export const NESTED_DEFAULTS_PRECEDENCE_TITLES: Record<
 export const NESTED_DEFAULTS_PRECEDENCE = Object.keys(
   NESTED_DEFAULTS_PRECEDENCE_TITLES
 ) as NestedDefaultsPrecedence[];
-
-// TODO: Remove in v4
-export type NormalizedFormState = Normalize<FormState>;
-
-// TODO: Remove in v4
-export function normalizeFormState(state: FormState): NormalizedFormState {
-  return {
-    ...state,
-    nestedDefaultsPrecedence: "descendantWins",
-    css: state.css ?? "",
-    validator: normalizeValidator(state.validator),
-    schema: normalizeJsonValue(state.schema),
-    uiSchema: normalizeJsonValue(state.uiSchema),
-    initialValue: normalizeJsonValue(state.initialValue),
-  };
-}

--- a/packages/meta/src/playground/merger-state.ts
+++ b/packages/meta/src/playground/merger-state.ts
@@ -1,28 +1,7 @@
-import type { FormValue, Schema } from "@sjsf/form";
-
-import { normalizeJsonValue, type Normalize } from "./model.ts";
-
-// NOTE: We use legacy types in combination with `| string`
-// to maintain compatibility with old URLs.
-// TODO: This should be removed in v4.
 export interface MergerState {
-  schema: Schema | string;
+  schema: string;
   deep: boolean;
   intersectJson: boolean;
   deduplicateJsonSchemas: boolean;
-  output: Schema | FormValue | string;
-}
-
-// TODO: Remove in v4
-export type NormalizedMergerState = Normalize<MergerState>;
-
-// TODO: Remove in v4
-export function normalizeMergerState(
-  state: MergerState
-): NormalizedMergerState {
-  return {
-    ...state,
-    schema: normalizeJsonValue(state.schema),
-    output: normalizeJsonValue(state.output),
-  };
+  output: string;
 }

--- a/packages/meta/src/playground/model.ts
+++ b/packages/meta/src/playground/model.ts
@@ -1,7 +1,6 @@
 import type { Schema } from "@sjsf/form";
 
 import {
-  codegemIsJsonSchemaValidator,
   codegenIsExternalValidator,
   codegenValidators,
 } from "../codegen/index.ts";
@@ -16,43 +15,6 @@ import {
 import type { Generated } from "../types.ts";
 import { validatorTitle } from "../validators.ts";
 
-// TODO: Remove in v4
-/** @deprecated */
-const DRAFT_2020_SUFFIX = `_2020`;
-
-// TODO: Remove in v4
-/** @deprecated */
-type With2020Suffix<T extends string> = `${T}${typeof DRAFT_2020_SUFFIX}`;
-
-// TODO: Remove in v4
-/** @deprecated */
-export function isEndsWith2020(v: string): v is With2020Suffix<string> {
-  return v.endsWith(DRAFT_2020_SUFFIX);
-}
-
-// TODO: Remove in v4
-/** @deprecated */
-export function without2020Suffix<V extends string>(
-  v: V | With2020Suffix<V>
-): V {
-  return isEndsWith2020(v) ? (v.slice(0, -DRAFT_2020_SUFFIX.length) as V) : v;
-}
-
-// TODO: Remove in v4
-/** @deprecated */
-export function* playgroundValidators() {
-  for (const v of codegenValidators()) {
-    if (!codegemIsJsonSchemaValidator(v) || v.precompiled) {
-      continue;
-    }
-    yield v.draft2020 ? (`${v.name}${DRAFT_2020_SUFFIX}` as const) : v.name;
-  }
-}
-
-// TODO: Remove in v4
-/** @deprecated */
-export type PlaygroundValidator1 = Generated<typeof playgroundValidators>;
-
 export function* playgroundValidators2() {
   for (const v of codegenValidators()) {
     if (!codegenIsExternalValidator(v)) {
@@ -64,26 +26,15 @@ export function* playgroundValidators2() {
 
 export type PlaygroundValidator2 = Generated<typeof playgroundValidators2>;
 
-export type PlaygroundValidator = PlaygroundValidator1 | PlaygroundValidator2;
-
-export function normalizeValidator(validator: PlaygroundValidator) {
-  return typeof validator === "string"
-    ? ({
-        name: without2020Suffix(validator),
-        draft2020: isEndsWith2020(validator),
-        precompiled: false,
-      } as const satisfies PlaygroundValidator2)
-    : validator;
-}
+export type PlaygroundValidator = PlaygroundValidator2;
 
 export function playgroundValidatorTitle(validator: PlaygroundValidator) {
-  const v = normalizeValidator(validator);
-  const title = validatorTitle(v.name);
+  const title = validatorTitle(validator.name);
   const suffixes: string[] = [];
-  if (v.precompiled) {
+  if (validator.precompiled) {
     suffixes.push("precompiled");
   }
-  if (v.draft2020) {
+  if (validator.draft2020) {
     suffixes.push("2020-12");
   }
   return `${title}${suffixes.length > 0 ? ` (${suffixes.join(", ")})` : ""}`;
@@ -118,20 +69,6 @@ export function playgroundIconSetTitle(iconSet: PlaygroundIconSet) {
 export type PlaygroundResolver = Resolver;
 
 export const playgroundResolvers = resolvers;
-
-// TODO: Remove in v4
-export function normalizeJsonValue<S>(str: string | S) {
-  return typeof str === "string" ? str : JSON.stringify(str, null, 2);
-}
-
-// TODO: Remove in v4
-export type Normalize<T> = {
-  [K in keyof T]-?: PlaygroundValidator2 extends T[K]
-    ? PlaygroundValidator2
-    : string extends T[K]
-      ? string
-      : T[K];
-};
 
 export function isDraft2020(schema: Schema) {
   return (

--- a/packages/meta/src/playground/sandbox.test.ts
+++ b/packages/meta/src/playground/sandbox.test.ts
@@ -3,18 +3,18 @@ import { describe, it, expect } from "vitest";
 
 import { codegenThemeOrSubTheme } from "../codegen/index.ts";
 import { jsonSchema, jsonUiSchema, jsonValue } from "./form-preset.ts";
-import type { NormalizedFormState } from "./form-state.ts";
+import type { FormState } from "./form-state.ts";
 import { playgroundValidators2, playgroundValidatorTitle } from "./model.ts";
 import { createSandboxFiles, type CustomComponents } from "./sandbox.ts";
 
-const BASE_FORM_STATE: NormalizedFormState = {
+const BASE_FORM_STATE: FormState = {
   schema: jsonSchema({
     type: "object",
     title: "Test",
     properties: { name: { type: "string" } },
   }),
   uiSchema: jsonUiSchema({}),
-  initialValue: jsonValue(null),
+  formData: jsonValue(null),
   css: "",
   disabled: false,
   html5Validation: false,
@@ -43,7 +43,7 @@ const CUSTOM_COMPONENTS: CustomComponents = {
   transparentLayout: "<stub>transparent</stub>",
 };
 
-function testCase(name: string, overrides: Partial<NormalizedFormState> = {}) {
+function testCase(name: string, overrides: Partial<FormState> = {}) {
   it(name, async () => {
     expect(
       await createSandboxFiles({
@@ -68,7 +68,7 @@ describe("sandbox-factory", () => {
 
   describe("validators", () => {
     for (const validator of playgroundValidators2()) {
-      const overrides: Partial<NormalizedFormState> = { validator };
+      const overrides: Partial<FormState> = { validator };
       if (validator.name === "zod4") {
         overrides.schema = `import * as z from "zod";\n\nexport default z.object({ name: z.string() })`;
       } else if (validator.name === "valibot") {

--- a/packages/meta/src/playground/sandbox.ts
+++ b/packages/meta/src/playground/sandbox.ts
@@ -22,8 +22,8 @@ import { extraPackage, type AbstractPackage } from "../package.ts";
 import { toTheme, type Theme } from "../themes.ts";
 import { WIDGETS } from "../widgets.generated.ts";
 import { isThemeBaseWidget, type ExtraWidgetFileNames } from "../widgets.ts";
-import type { NormalizedFormState } from "./form-state.ts";
-import { normalizeValidator, type PlaygroundTheme } from "./model.ts";
+import type { FormState } from "./form-state.ts";
+import { type PlaygroundTheme } from "./model.ts";
 import { parseFormData, parseUiSchema } from "./parse.ts";
 import { WIDGET_EXTRA_FIELD } from "./widget-extra-fields.ts";
 
@@ -39,7 +39,7 @@ export interface SandboxFiles {
 
 function getChangedMergerOptionsCount(
   options: Pick<
-    NormalizedFormState,
+    FormState,
     | "arrayMinItemsPopulate"
     | "arrayMinItemsMergeExtraDefaults"
     | "allOf"
@@ -173,7 +173,7 @@ function detectCustomComponentsAndFields(
 
 export interface SandboxFilesOptions {
   name: string;
-  formState: NormalizedFormState;
+  formState: FormState;
   customComponents: CustomComponents;
 }
 
@@ -182,11 +182,11 @@ export async function createSandboxFiles({
   formState,
   customComponents: { markdownDescription, transparentLayout },
 }: SandboxFilesOptions) {
-  const validator = normalizeValidator(formState.validator);
+  const validator = formState.validator;
 
   const [uiSchema, initialValue] = await Promise.all([
     parseUiSchema(formState.uiSchema),
-    parseFormData(formState.initialValue),
+    parseFormData(formState.formData),
   ]);
 
   const {

--- a/packages/meta/src/playground/validator-state.ts
+++ b/packages/meta/src/playground/validator-state.ts
@@ -1,34 +1,8 @@
-import type { FormValue, Schema, ValidationResult } from "@sjsf/form";
+import type { PlaygroundValidator } from "./model.ts";
 
-import {
-  normalizeJsonValue,
-  normalizeValidator,
-  type Normalize,
-  type PlaygroundValidator,
-} from "./model.ts";
-
-// NOTE: We use legacy types in combination with `| string`
-// to maintain compatibility with old URLs.
-// TODO: This should be removed in v4.
 export interface ValidatorState {
-  schema: Schema | string;
-  input: FormValue | string;
-  output: ValidationResult<unknown>["errors"] | string;
+  schema: string;
+  input: string;
+  output: string;
   validator: PlaygroundValidator;
-}
-
-// TODO: Remove in v4
-export type NormalizedValidatorState = Normalize<ValidatorState>;
-
-// TODO: Remove in v4
-export function normalizeValidatorState(
-  state: ValidatorState
-): NormalizedValidatorState {
-  return {
-    ...state,
-    validator: normalizeValidator(state.validator),
-    schema: normalizeJsonValue(state.schema),
-    input: normalizeJsonValue(state.input),
-    output: normalizeJsonValue(state.output),
-  };
 }

--- a/packages/meta/src/playground/validators.ts
+++ b/packages/meta/src/playground/validators.ts
@@ -1,6 +1,5 @@
 import type { Draft2020, Precompiled } from "../codegen/index.ts";
 import {
-  normalizeValidator,
   type PlaygroundValidator,
   type PlaygroundValidator2,
 } from "./model.ts";
@@ -54,7 +53,7 @@ const PRECOMPILED_DRAFT_07: Record<
 };
 
 export function playgroundValidator<T>(options: ValidatorFactoryOptions) {
-  const v: PlaygroundValidator2 = normalizeValidator(options.validator);
+  const v: PlaygroundValidator2 = options.validator;
   const factory = v.precompiled
     ? PRECOMPILED_DRAFT_07[v.name]
     : v.draft2020


### PR DESCRIPTION
- Remove draft-2020 suffix helpers (isEndsWith2020, without2020Suffix, DRAFT_2020_SUFFIX)
- Remove legacy generators (playgroundValidators, builderValidators)
- Remove normalization functions (normalizeValidator, normalizeJsonValue, Normalize<T>)
- Remove NormalizedFormState, NormalizedMergerState, NormalizedValidatorState, NormalizedFormPreset
- Make FormState/MergerState/ValidatorState fields string-only
- Rename FormState.initialValue to FormState.formData
- Make FormState.css and nestedDefaultsPrecedence required
- Update all consumers in meta, playground2, and builder